### PR TITLE
Add Chrome extension for Amazon URL shortening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # amazonurlshortener
-Shortens Amazon URLs from browser for easy sharing.
+
+Chrome extension that shortens Amazon URLs from the browser for easy sharing.
+
+## Usage
+
+1. Open Chrome and navigate to `chrome://extensions/`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this folder.
+4. Click the extension icon while on an Amazon page to get the shortened link and copy it to your clipboard.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Amazon URL Shortener",
+  "description": "Automatically shortens Amazon URLs for easy sharing.",
+  "version": "1.0",
+  "permissions": ["tabs", "activeTab", "clipboardWrite"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Shorten Amazon URL"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: Arial, sans-serif; width: 250px; padding: 10px; }
+    #url { word-break: break-all; margin-bottom: 10px; }
+    button { padding: 5px 10px; }
+  </style>
+</head>
+<body>
+  <div id="url">Loading...</div>
+  <button id="copy">Copy to clipboard</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,25 @@
+function shortenAmazonUrl(url) {
+  try {
+    const u = new URL(url);
+    if (u.hostname.endsWith('amazon.com')) {
+      const dpIndex = u.pathname.indexOf('/dp/');
+      if (dpIndex !== -1) {
+        const asin = u.pathname.substring(dpIndex + 4).split('/')[0];
+        return `https://${u.hostname}/dp/${asin}`;
+      }
+    }
+  } catch (e) {}
+  return url;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+    const tab = tabs[0];
+    const shortened = shortenAmazonUrl(tab.url);
+    const urlDiv = document.getElementById('url');
+    urlDiv.textContent = shortened;
+    document.getElementById('copy').addEventListener('click', () => {
+      navigator.clipboard.writeText(shortened);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement Chrome extension that shortens Amazon URLs
- add popup to display shortened link and copy to clipboard
- document how to load the extension in Chrome

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847abe893608323a783788a5079168a